### PR TITLE
Fix on Turkish grammar/translation of words and links to /tr instead of /tk

### DIFF
--- a/templates/parts/bonusTableTr.html
+++ b/templates/parts/bonusTableTr.html
@@ -21,21 +21,21 @@
 
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/checkerboard.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/checkerBoard.html">Dama Tahtası</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/checkerBoard.html">Dama Tahtası</a></td>
 						<td>&#9733;&#9733;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusKarel.zip">BonusKarel.zip</a> </td>
 					</tr>
 
 					<tr class="table-bordered table-striped">
                         <td><img style="width:auto;max-height:100px" class="projectImg" src="{{pathToRoot}}img/icons/squarePainter.png"></img></a></td>
-						<td><a href="{{pathToRoot}}tk/projects/squarePainter.html">Kare Boyama</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/squarePainter.html">Kare Boyama</a></td>
 						<td>&#9733;&#9733;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusKarel.zip">BonusKarel.zip</a> </td>
 					</tr>
 
 					<tr class="table-bordered table-striped">
                         <td><img style="height:auto;maxwidth:150px" class="projectImg" src="{{pathToRoot}}img/icons/midpoint.png"></img></a></td>
-						<td><a href="{{pathToRoot}}tk/projects/midpointKarel.html">Orta Nokta</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/midpointKarel.html">Orta Nokta</a></td>
 						<td>&#9733;&#9733;&#9733;</td>
 						<td><a href="{{pathToRoot}}starter/BonusKarel.zip">BonusKarel.zip</a> </td>
 					</tr>
@@ -47,30 +47,30 @@
 					<tr>
 						<th colspan = "6"><b>
 						<br>
-						[Variables]</b></th>
+						[Değişkenler]</b></th>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td ><img style="width:auto;max-height:100px" class="projectImg" src="{{pathToRoot}}img/icons/console.jpg"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/consoleBonus.html">Bonus Konsol</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/consoleBonus.html">Bonus Konsol</a></td>
 						<td>&#9733;&#9734;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusConsole.zip">BonusConsole.zip</a></td>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td ><img style="height:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/loopingfun.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/loopingFun.html">Eğlenceli Döngüler</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/loopingFun.html">Eğlenceli Döngüler</a></td>
 						<td>&#9733;&#9734;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusConsole.zip">BonusConsole.zip</a></td>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/hailstone.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/hailstone.html">Dolu Tanesi</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/hailstone.html">Dolu Tanesi</a></td>
 						<td>&#9733;&#9733;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusConsole.zip">BonusConsole.zip</a></td>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/carbonDating.jpg"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/carbonDating.html">Karbon Tarihi Saptama</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/carbonDating.html">Karbon Tarihi Saptama</a></td>
 						<td>&#9733;&#9733;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusConsole.zip">BonusConsole.zip</a></td>
 
@@ -81,25 +81,25 @@
 					<tr>
 						<th colspan = "6"><b>
 						<br>
-						[Graphics]</b></th>
+						[Grafik]</b></th>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px;border:1px solid grey" class="projectImg" src="{{pathToRoot}}img/icons/bouncingMultiple.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/multipleBalls.html">Birkaç Top</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/multipleBalls.html">Birkaç Top</a></td>
 						<td>&#9733;&#9734;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusGraphics.zip">BonusGraphics.zip</a></td>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px;border:1px solid grey" class="projectImg" src="{{pathToRoot}}img/icons/creativeGraphics.jpg"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/creativeGraphics.html">Yaratıcı Grafik</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/creativeGraphics.html">Yaratıcı Grafik</a></td>
 						<td>&#9733;&#9734;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusGraphics.zip">BonusGraphics.zip</a></td>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td ><img style="width:auto;max-height:100px" class="projectImg" src="{{pathToRoot}}img/icons/creativeStringArt.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/creativeStringArt.html">Yaratıcı String Sanatı</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/creativeStringArt.html">Yaratıcı String Sanatı</a></td>
 						<td>&#9733;&#9734;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusGraphics.zip">BonusGraphics.zip</a></td>
 					</tr>
@@ -112,30 +112,30 @@
 					<tr>
 						<th colspan = "6"><b>
 						<br>
-						[Advanced Java]</b></th>
+						[İleri Java]</b></th>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/moreMethods.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/moreMethods.html">Daha Fazla Metotlar</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/moreMethods.html">Daha Fazla Metotlar</a></td>
 						<td>&#9733;&#9734;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusMethods.zip">BonusMethods.zip</a></td>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/countdown.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/countdown.html">Geri Sayım</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/countdown.html">Geri Sayım</a></td>
 						<td>&#9733;&#9733;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusMethods.zip">BonusMethods.zip</a></td>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/numberGrid.jpg"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/numberGrid.html">Sayı Şebekesi</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/numberGrid.html">Sayı Şebekesi</a></td>
 						<td>&#9733;&#9733;&#9733;</td>
 						<td><a href="{{pathToRoot}}starter/MoreMethods.zip">BonusMethods.zip</a></td>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/borderBox.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/borderBox.html">Sınırdaki Kutu</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/borderBox.html">Sınırdaki Kutu</a></td>
 						<td>&#9733;&#9733;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusMethods.zip">BonusMethods.zip</a></td>
 					</tr>
@@ -153,13 +153,13 @@
 
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px" class="projectImg" src="{{pathToRoot}}img/icons/duplicateShape.jpg"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/duplicatingShapes.html">Şekilleri Çoklama</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/duplicatingShapes.html">Şekilleri Çoklama</a></td>
 						<td>&#9733;&#9734;&#9734;</td>
 						<td><a href="{{pathToRoot}}starter/BonusEvents.zip">BonusEvents.zip</a></td>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td><img style="width:auto;max-height:100px;max-width:150px;border:1px solid grey" class="projectImg" src="{{pathToRoot}}img/icons/clickNStuff.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/clickNStuff.html">Tıklama Falan</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/clickNStuff.html">Tıklama Falan</a></td>
 						<td>&#9733;&#9733;&#9733;</td>
 						<td><a href="{{pathToRoot}}starter/BonusEvents.zip">BonusEvents.zip</a></td>
 					</tr>
@@ -172,11 +172,11 @@
 					<tr>
 						<th colspan = "6"><b>
 						<br>
-						[ArrayLists]</b></th>
+						[Dizi Listeleri (ArrayLists)]</b></th>
 					</tr>
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/borderSnake.png"></img></td>
-						<td><a href="{{pathToRoot}}tk/projects/borderSnake.html">Sınırdaki yılan</a></td>
+						<td><a href="{{pathToRoot}}tr/projects/borderSnake.html">Sınırdaki yılan</a></td>
 						<td>&#9733;&#9733;&#9733;</td>
 						<td><a href="{{pathToRoot}}starter/BonusArrays.zip">BonusArrays.zip</a></td>
 					</tr>

--- a/templates/parts/navBarTr.html
+++ b/templates/parts/navBarTr.html
@@ -26,7 +26,7 @@
 	          	<li><a href="{{pathToRoot}}tr/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a></li>
 	          	<li><a href="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a></li>
 	          	<li><a href="{{pathToRoot}}tr/handouts/events.html">Olaylar(Events) Referansı</a></li>
-	          	<li><a href="{{pathToRoot}}tr/handouts/arrayLists.html">Array Lists</a></li>
+	          	<li><a href="{{pathToRoot}}tr/handouts/arrayLists.html">Array Listeleri (ArrayLists)</a></li>
 	          	<!--
 	          	<li><a href="{{pathToRoot}}handouts/events.html">Olaylar(Events) Referansı</a></li>
                 <li><a href="{{pathToRoot}}projects/jsJSSyntax.html">JavaScript Referansı</a></li>
@@ -57,8 +57,8 @@
 	          	<li><a href="{{pathToRoot}}tr/projects/randomPainter.html">Deli Ressam</a></li>
 	          	<li class="divider"></li>
 
-	          	<li><a href="{{pathToRoot}}tr/projects/sandcastles.html">Sandcastles</a></li>
-	          	<li><a href="{{pathToRoot}}tr/projects/favoriteNumber.html">Favorite Number</a></li>
+	          	<li><a href="{{pathToRoot}}tr/projects/sandcastles.html">Kumdan Kaleler</a></li>
+	          	<li><a href="{{pathToRoot}}tr/projects/favoriteNumber.html">En Sevdiğim Numara</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/medicine.html">Sahte İlaç</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/someSum.html">Üç Aşağı Beş Yukarı</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/gameOfStones.html">Nimm</a></li>
@@ -66,14 +66,14 @@
 	          	<li class="divider"></li>
 
 	          	<li><a href="{{pathToRoot}}tr/projects/awesome.html">Programcılık Bir Harika</a></li>
-	          	<li><a href="{{pathToRoot}}tr/projects/stringArt.html">String Art</a></li>
+	          	<li><a href="{{pathToRoot}}tr/projects/stringArt.html">String Sanatı</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/randomCircles.html">Tesadüfi Daireler</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/hailstone.html">Dolu Tanesi</a></li>
 
 	            <li class="divider"></li>
-	            <li><a href="{{pathToRoot}}tr/projects/bouncingBall.html">Zıp zıp top</a></li>
+	            <li><a href="{{pathToRoot}}tr/projects/bouncingBall.html">Zıp Zıp Top</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/madMethods.html">Çılgın Metotlar</a></li>
-	          	<li><a href="{{pathToRoot}}tr/projects/target.html">Hedef</a></li>
+	          	<li><a href="{{pathToRoot}}tr/projects/target.html">Hedef Tahtası</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/illusion.html">Optik İllüzyon</a></li>
 	          	<li><a href="{{pathToRoot}}tr/projects/sunset.html">Kısa Film</a></li>
 
@@ -135,9 +135,9 @@
 	          	<li class="divider"></li>
 	            <li><a href="{{pathToRoot}}tr/projects/emc2.html">E=MC2</a></li>
 	            <li><a href="{{pathToRoot}}tr/projects/fibb.html">Fibonacci</a></li>
-	           <li><a href="{{pathToRoot}}en/projects/favoriteNumber.html">En Sevdiğim Numara</a></li>
-	           <li><a href="{{pathToRoot}}en/projects/findPi.html">Pi'yi Bul</a></li>
-	           <li><a href="{{pathToRoot}}en/projects/8Ball.html">8 Numaralı Top</a></li>
+	           <li><a href="{{pathToRoot}}tr/projects/favoriteNumber.html">En Sevdiğim Numara</a></li>
+	           <li><a href="{{pathToRoot}}tr/projects/findPi.html">Pi'yi Bul</a></li>
+	           <li><a href="{{pathToRoot}}tr/projects/8Ball.html">8 Numaralı Top</a></li>
 
 	           <li class="divider"></li>
 	           <li><a href="{{pathToRoot}}tr/projects/robotFace.html">Robot Surat</a></li>
@@ -188,7 +188,7 @@
 	          	<li><a href="{{pathToRoot}}slides/Review.pdf">Özet</a></li>
 	          	<li><a href="{{pathToRoot}}slides/Events.pdf">Events</a></li>
 	          	<li><a href="{{pathToRoot}}slides/Internet.pdf">Internet</a></li>
-	          	<li><a href="{{pathToRoot}}slides/Arrays.pdf">Arrays</a></li>
+	          	<li><a href="{{pathToRoot}}slides/Arrays.pdf">Diziler (Arrays)</a></li>
 	          	<li><a href="{{pathToRoot}}slides/ArrayLists.pdf">Array Lists</a></li>
 	          	<li><a href="{{pathToRoot}}slides/Strings.pdf">Strings</a></li>
 							<!--

--- a/templates/parts/programTableTr.html
+++ b/templates/parts/programTableTr.html
@@ -75,41 +75,41 @@
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/numbers.jpg"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/sortedNumbers.html">Sıralayıcı</a></td>
-						<td>ArrayLists</td>
+						<td>Dizi Listeleri (ArrayLists)</td>
 						<td><a href="{{pathToRoot}}starter/Day7.zip">Day7.zip</a></td>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/snow.png"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/snow.html">Kar</a></td>
-						<td>ArrayLists</td>
+						<td>Dizi Listeleri (ArrayLists)</td>
 						<td><a href="{{pathToRoot}}starter/Day7.zip">Day7.zip</a></td>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/mouseGame.png"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/mouseGame.html">[Opsiyonel] Patika</a></td>
-						<td>ArrayLists</td>
+						<td>Dizi Listeleri (ArrayLists)</td>
 						<td><a href="{{pathToRoot}}starter/Day7.zip">Day7.zip</a> </td>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/music3.jpg"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/music.html">[Opsiyonel] Ses Dalgaları</a></td>
-						<td>ArrayLists</td>
+						<td>Dizi Listeleri (ArrayLists)</td>
 						<td><a href="{{pathToRoot}}starter/Day7.zip">Day7.zip</a> </td>
 					</tr>
 					
 					<tr>
 						<th colspan = "6"><b>
 						<br>
-						[Arrays]</b></th>
+						[Diziler (Arrays)]</b></th>
 					</tr>
 
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/racingCars.jpg"></img></td>
-						<td>Array Alıştırması!</td>
-						<td>Arrays</td>
+						<td>Dizi Alıştırması!</td>
+						<td>Diziler (Arrays)</td>
 						<td><a href="{{pathToRoot}}starter/Day6.zip">Day6.zip</a></td>
 					</tr>
 
@@ -122,7 +122,7 @@
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/breakout.jpg"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/breakout.html">Breakout!</a></td>
-						<td>Interactors</td>
+						<td>Etkileşim (Interactors)</td>
 						<td><a href="{{pathToRoot}}starter/Breakout.zip">Breakout.zip</a></td>
 					</tr>
 
@@ -196,7 +196,7 @@
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/mysterySquare.png"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/mysterySquare.html">Gizemli Kare</a></td>
-						<td>Rastgelelilik</td>
+						<td>Rastgelelik</td>
 						<td><a href="{{pathToRoot}}starter/Day2.zip">Day3.zip</a></td>
 					</tr>
 
@@ -210,7 +210,7 @@
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/randomCircles.png"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/randomCircles.html">Tesadüfi Daireler</a></td>
-						<td>Rastgelelilik</td>
+						<td>Rastgelelik</td>
 						<td><a href="{{pathToRoot}}starter/Day3.zip">Day3.zip</a></td>
 					</tr>
 
@@ -244,7 +244,7 @@
 					<tr class="table-bordered table-striped">
 						<td><img class="projectImg" src="{{pathToRoot}}img/icons/medicine.png"></img></td>
 						<td><a href="{{pathToRoot}}tr/projects/medicine.html">Sahte İlaç</a></td>
-						<td>Concatenation</td>
+						<td>Eklemleme (Concatenation)</td>
 						<td><a href="{{pathToRoot}}starter/Day2.zip">Day2.zip</a></td>
 					</tr>
 

--- a/templates/tr/handouts/arrayLists.html
+++ b/templates/tr/handouts/arrayLists.html
@@ -16,7 +16,7 @@
 		<!-- Header -->
 		<div id="pageHeader">
 			<h1>
-				ArrayList Referansı
+				Dizi Listeleri (ArrayList Referansı
 			</h1>
 			<p>
 				Yazan Eric Roberts

--- a/templates/tr/handouts/events.html
+++ b/templates/tr/handouts/events.html
@@ -16,7 +16,7 @@
 		<!-- Header -->
 		<div id="pageHeader">
 			<h1>
-				Olaylar (Event) Referansı
+				Olaylar (Events) Referansı
 			</h1>
 			<p>
 				Yazanlar Danielle Kain ve Kevin Miller

--- a/templates/tr/handouts/graphics.html
+++ b/templates/tr/handouts/graphics.html
@@ -32,7 +32,7 @@
 				<br/>
 
 				<p>
-					Diğer kullanışlı comutlar ise:
+					Diğer kullanışlı komutlar ise:
 				</p>
 
 					<div class="well"><code>

--- a/templates/tr/handouts/operations.html
+++ b/templates/tr/handouts/operations.html
@@ -27,18 +27,18 @@
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Local Variable'lar (Yerel Değişkenler)</h3>
+				<h3>Yerel Değişkenler (Local Variables)</h3>
 				<p>
-					Local variable'lar içinde yazıldıkları metod (veya bloklar, fazlası için aşağıdaki "Blok Kapsamı" bölümüne bakın) için yaratılır. Metodun yürütmesi bittiğinde de yok edilirler. Local variable'lar sadece içinde yazıldıkları metodda kullanılabilirler. Bu geçici özelliklerinden ötürü local variable'lar birden fazla metodda kullanılması gereken kalıcı bilgileri saklamak için kullanılmazlar.
+					Yerel Değişkenler içinde yazıldıkları metot (veya bloklar, fazlası için aşağıdaki "Blok Kapsamı" bölümüne bakın) için yaratılır. Metodun yürütmesi bittiğinde de yok edilirler. Yerel değişkenler sadece içinde yazıldıkları metotta kullanılabilirler. Bu geçici özelliklerinden ötürü Yerel değişkenler birden fazla metotta kullanılması gereken kalıcı bilgileri saklamak için kullanılmazlar.
 				</p>
 			</div>
 		</div>
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Local Variable Örnekleri</h3>
+				<h3>Yerel Değişken Örnekleri</h3>
 				<p>
-					Mesela aşağıdaki kod parçasına bakın.
+					Örnek olarak aşağıdaki kod parçasına bakın.
 				</p>
 				<pre id="editor" style="height:200px">public class AnExample extends ConsoleProgram {
 
@@ -48,16 +48,16 @@
  	}
 
 	public void methodTwo {
-		int b = a;  // BUG!: methodOne'da yazılmış local variable a methodTwo'da kullanılamaz.
+		int b = a;  // BUG!: methodOne'da yazılmış yerel değişkenler methodTwo içerisinde kullanılamaz.
 		println("b = " + b);
 	}
 }</pre>
 				<p>
-					a ve b variable'ları, AnExample class'ı içerisindeki farklı metodların içinde yazılmış local variable'lar. Bu variable'lar local variable'lar oldukları için a sadece methodOne'da, b ise sadece methodTwo'da erişilebilir. b variable'ını a'nın değerini kullanarak yaratmamız çalışmıyor çünkü methodTwo'da yazılan bu kod methodOne ya da başka herhangi bir method'daki local variable'ları kullanamaz.
+					a ve b değişkenleri, AnExample class'ı içerisindeki farklı metotların içinde yazılmış yerel değişkenlerdir. Bu değişkenler yerel oldukları için a sadece methodOne'da, b ise sadece methodTwo'da erişilebilir. b değişkenini a'nın değerini kullanarak yaratmamız hata veriyor çünkü methodTwo'da yazılan bu kod methodOne ya da başka herhangi bir metottaki yerel değişkenleri kullanamaz.
 				</p>
 				<p>
-				Local variable'ların değerleri içinde oldukları metodun yürütmesi bittikten sonra saklanmadığı için, methodOne'ın yürütmesi bittikten sonra a variable'ı yok olacak. methodOne tekrar yürütüldüğünde ise sıfırdan yeni bir a variable'ı yaratılacak.
-			</p>
+					Yerel değişkenlerin değerleri, içinde oldukları metodun yürütmesi bittikten sonra silindiği için, methodOne'ın yürütmesi bittikten sonra a değişkeni yok olacaktır. methodOne tekrar yürütüldüğünde ise sıfırdan yeni bir a değişkeni yaratılacak.
+				</p>
 			</div>
 		</div>
 
@@ -65,8 +65,8 @@
 			<div class="col-md-12">
 				<h3>Blok Kapsamı</h3>
 				<p>
-					Genelde local variable'ları belli bir metoda ait olarak düşünürüz, ancak aslında Java'da local variable'lar belli bir kod bloğuna aittir. Metodlar sadece bir çeşit kod bloğudur. Java'da kodun etrafına konan süslü parantezler ("{" ve "}") bir kod bloğu belirler. Mesela bir metodun başına ve sonuna konan süslü parantezler onu bir kod bloğu yapar. Ama aynısı for ve while döngüleri ve if kalıpları da kod bloklarıdır (etraflarında süslü parantez olduğu için). Java'da etrafında süslü parantez olan tüm kod grupları bir kod bloğudur.
-					Ne zaman bir süslü parantez çiftinin içinde bir variable yaratsak, o variable o kod bloğuna ait bir local variable olur ve ancak o blok içerisinde kullanılabilir. Ne zaman o kod bloğunun yürütmesi biterse o zaman da yok edilir.</p>
+					Genelde yerel değişkenleri belli bir metoda ait olarak düşünürüz, ancak aslında Java'da yerel değişkenler belli bir kod bloğuna aittir. Metodlar sadece bir çeşit kod bloğudur. Java'da kodun etrafına konan süslü parantezler ("{" ve "}") bir kod bloğu belirler. Mesela bir metodun başına ve sonuna konan süslü parantezler onu bir kod bloğu yapar. Ama aynısı for ve while döngüleri ve if kalıpları için de geçerlidir (etraflarında süslü parantez olduğu için). Java'da etrafında süslü parantez olan tüm kod grupları bir kod bloğudur.
+					Ne zaman bir süslü parantez çiftinin içinde bir değişken yaratsak, o değişken bulunduğu kod bloğuna ait bir yerel değişken olur ve ancak o blok içerisinde kullanılabilir. Ne zaman o kod bloğunun yürütmesi biterse o zaman da yok edilir.</p>
 				<p>Aşağıdaki örneğe bakın:</p>
 				<pre id="editor2" style="height:400px">public class AnExample extends ConsoleProgram {
 	
@@ -93,7 +93,7 @@
 	}
 }</pre>
 				<p>
-					a variable'ı methodThree'ye ait bir local variable, dolayısıyla hem for döngüsünün hem de println'nin içinde kullanılabilir. i ve b variable'ları ise sadece içinde yazıldıkları for loop'un içerisinde kapsam içindeler. Sondaki iki println yürütüldüğü zaman artık erişilebilir değiller. c variable'ı ise sadece içinde yazıldığı if kalıbının içinde kullanılabilir. Unutmayın ki for döngüsünün her bir döngüsünde if kalıbı baştan yürütüldüğü için c variable'ı da baştan yaratılıyor, dolayısıyla c variable'ı for'un farklı döngüleri arasında veri saklamaya uygun değil.
+					a değişkeni methodThree'ye ait bir yerel değişken, dolayısıyla hem for döngüsünün hem de println'nin içinde kullanılabilir. i ve b variable'ları ise sadece içinde yazıldıkları for döngüsü boyunca kapsam içindedirler. Sondaki iki println yürütüldüğü zaman artık erişilebilir olmayacaklardır. c değişkeni ise sadece içinde yazıldığı if kalıbının içinde kullanılabilir. Unutmayın ki for döngüsünün her bir döngüsünde if kalıbı baştan yürütüldüğü için c değişkeni de baştan yaratılıyor, dolayısıyla c değişkeni for'un farklı döngüleri arasında veri saklamaya uygun değil.
 				</p>
 			</div>
 		</div>
@@ -105,11 +105,11 @@
 		</div>-->
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Constant'lar (Sabitler)</h3>
+				<h3>Sabitler (Constants)</h3>
 				<p>
-					Kimi zaman program çalıştığı süre boyunca değeri hiç değişmeyecek olan bir variable yaratmak isteyebiliriz. Böyle variable'lara "constant" denir. Constant'lar normalde variable'ların kullanıldığı durumlarda kullanılmaz (mesela geçici bir değeri saklamak). Bir variable'ı constant olarak yaratmak için variable'ı ilk yazarken başına "final" kelimesini ekleyin. Constant'lar tüm metodların dışında yazılır, dolayısıyla kapsamları bütün programdır.
+					Kimi zaman program çalıştığı süre boyunca değeri hiç değişmeyecek olan bir değişken yaratmak isteyebiliriz. Böyle değişkenlere "sabit (constant)" denir. Sabitler normalde değişkenlerin kullanıldığı durumlarda kullanılmaz (örneğin geçici bir değeri saklamak). Bir değişkeni sabit olarak yaratmak için değişkeni ilk yazarken başına "final" kelimesini ekleyin. Sabitler tüm metodların dışında yazılır, dolayısıyla kapsamları bütün programdır.
 				</p>
-				<p> Constant'lar genellikle büyük harflerle yazılır. Bunun amacı onların constant olduğunu ve hiç değişmeyeceklerini belirtmektir. "private static final" kelimelerini ise iyi bir kodlama alışkanlığı olarak ekleriz. Bu kelimeler özellikle daha büyük programlar yazdığınızda önemli olacaktır.
+				<p> Sabitler genellikle büyük harflerle yazılır. Bunun amacı onların sabit olduğunu ve hiç değişmeyeceklerini belirtmektir. "private static final" kelimelerini ise iyi bir kodlama alışkanlığı olarak ekleriz. Bu kelimeler özellikle daha büyük programlar yazdığınızda önemli olacaktır.
 				<p>
 					Aşağıdaki örneğe bakın:
 				</p>

--- a/templates/tr/handouts/scope.html
+++ b/templates/tr/handouts/scope.html
@@ -27,18 +27,18 @@
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Local Variable'lar (Yerel Değişkenler)</h3>
+				<h3>Yerel Değişkenler (Local Variables)</h3>
 				<p>
-					Local variable'lar içinde yazıldıkları metod (veya bloklar, fazlası için aşağıdaki "Blok Kapsamı" bölümüne bakın) için yaratılır. Metodun yürütmesi bittiğinde de yok edilirler. Local variable'lar sadece içinde yazıldıkları metodda kullanılabilirler. Bu geçici özelliklerinden ötürü local variable'lar birden fazla metodda kullanılması gereken kalıcı bilgileri saklamak için kullanılmazlar.
+					Yerel Değişkenler içinde yazıldıkları metot (veya bloklar, fazlası için aşağıdaki "Blok Kapsamı" bölümüne bakın) için yaratılır. Metodun yürütmesi bittiğinde de yok edilirler. Yerel değişkenler sadece içinde yazıldıkları metotta kullanılabilirler. Bu geçici özelliklerinden ötürü Yerel değişkenler birden fazla metotta kullanılması gereken kalıcı bilgileri saklamak için kullanılmazlar.
 				</p>
 			</div>
 		</div>
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Local Variable Örnekleri</h3>
+				<h3>Yerel Değişken Örnekleri</h3>
 				<p>
-					Mesela aşağıdaki kod parçasına bakın.
+					Örnek olarak aşağıdaki kod parçasına bakın.
 				</p>
 				<pre id="editor" style="height:200px">public class AnExample extends ConsoleProgram {
 
@@ -48,16 +48,16 @@
  	}
 
 	public void methodTwo {
-		int b = a;  // BUG!: methodOne'da yazılmış local variable a methodTwo'da kullanılamaz.
+		int b = a;  // BUG!: methodOne'da yazılmış yerel değişkenler methodTwo içerisinde kullanılamaz.
 		println("b = " + b);
 	}
 }</pre>
 				<p>
-					a ve b variable'ları, AnExample class'ı içerisindeki farklı metodların içinde yazılmış local variable'lar. Bu variable'lar local variable'lar oldukları için a sadece methodOne'da, b ise sadece methodTwo'da erişilebilir. b variable'ını a'nın değerini kullanarak yaratmamız çalışmıyor çünkü methodTwo'da yazılan bu kod methodOne ya da başka herhangi bir method'daki local variable'ları kullanamaz.
+					a ve b değişkenleri, AnExample class'ı içerisindeki farklı metotların içinde yazılmış yerel değişkenlerdir. Bu değişkenler yerel oldukları için a sadece methodOne'da, b ise sadece methodTwo'da erişilebilir. b değişkenini a'nın değerini kullanarak yaratmamız hata veriyor çünkü methodTwo'da yazılan bu kod methodOne ya da başka herhangi bir metottaki yerel değişkenleri kullanamaz.
 				</p>
 				<p>
-				Local variable'ların değerleri içinde oldukları metodun yürütmesi bittikten sonra saklanmadığı için, methodOne'ın yürütmesi bittikten sonra a variable'ı yok olacak. methodOne tekrar yürütüldüğünde ise sıfırdan yeni bir a variable'ı yaratılacak.
-			</p>
+					Yerel değişkenlerin değerleri, içinde oldukları metodun yürütmesi bittikten sonra silindiği için, methodOne'ın yürütmesi bittikten sonra a değişkeni yok olacaktır. methodOne tekrar yürütüldüğünde ise sıfırdan yeni bir a değişkeni yaratılacak.
+				</p>
 			</div>
 		</div>
 
@@ -65,8 +65,8 @@
 			<div class="col-md-12">
 				<h3>Blok Kapsamı</h3>
 				<p>
-					Genelde local variable'ları belli bir metoda ait olarak düşünürüz, ancak aslında Java'da local variable'lar belli bir kod bloğuna aittir. Metodlar sadece bir çeşit kod bloğudur. Java'da kodun etrafına konan süslü parantezler ("{" ve "}") bir kod bloğu belirler. Mesela bir metodun başına ve sonuna konan süslü parantezler onu bir kod bloğu yapar. Ama aynısı for ve while döngüleri ve if kalıpları da kod bloklarıdır (etraflarında süslü parantez olduğu için). Java'da etrafında süslü parantez olan tüm kod grupları bir kod bloğudur.
-					Ne zaman bir süslü parantez çiftinin içinde bir variable yaratsak, o variable o kod bloğuna ait bir local variable olur ve ancak o blok içerisinde kullanılabilir. Ne zaman o kod bloğunun yürütmesi biterse o zaman da yok edilir.</p>
+					Genelde yerel değişkenleri belli bir metoda ait olarak düşünürüz, ancak aslında Java'da yerel değişkenler belli bir kod bloğuna aittir. Metodlar sadece bir çeşit kod bloğudur. Java'da kodun etrafına konan süslü parantezler ("{" ve "}") bir kod bloğu belirler. Mesela bir metodun başına ve sonuna konan süslü parantezler onu bir kod bloğu yapar. Ama aynısı for ve while döngüleri ve if kalıpları için de geçerlidir (etraflarında süslü parantez olduğu için). Java'da etrafında süslü parantez olan tüm kod grupları bir kod bloğudur.
+					Ne zaman bir süslü parantez çiftinin içinde bir değişken yaratsak, o değişken bulunduğu kod bloğuna ait bir yerel değişken olur ve ancak o blok içerisinde kullanılabilir. Ne zaman o kod bloğunun yürütmesi biterse o zaman da yok edilir.</p>
 				<p>Aşağıdaki örneğe bakın:</p>
 				<pre id="editor2" style="height:400px">public class AnExample extends ConsoleProgram {
 	
@@ -93,7 +93,7 @@
 	}
 }</pre>
 				<p>
-					a variable'ı methodThree'ye ait bir local variable, dolayısıyla hem for döngüsünün hem de println'nin içinde kullanılabilir. i ve b variable'ları ise sadece içinde yazıldıkları for loop'un içerisinde kapsam içindeler. Sondaki iki println yürütüldüğü zaman artık erişilebilir değiller. c variable'ı ise sadece içinde yazıldığı if kalıbının içinde kullanılabilir. Unutmayın ki for döngüsünün her bir döngüsünde if kalıbı baştan yürütüldüğü için c variable'ı da baştan yaratılıyor, dolayısıyla c variable'ı for'un farklı döngüleri arasında veri saklamaya uygun değil.
+					a değişkeni methodThree'ye ait bir yerel değişken, dolayısıyla hem for döngüsünün hem de println'nin içinde kullanılabilir. i ve b variable'ları ise sadece içinde yazıldıkları for döngüsü boyunca kapsam içindedirler. Sondaki iki println yürütüldüğü zaman artık erişilebilir olmayacaklardır. c değişkeni ise sadece içinde yazıldığı if kalıbının içinde kullanılabilir. Unutmayın ki for döngüsünün her bir döngüsünde if kalıbı baştan yürütüldüğü için c değişkeni de baştan yaratılıyor, dolayısıyla c değişkeni for'un farklı döngüleri arasında veri saklamaya uygun değil.
 				</p>
 			</div>
 		</div>
@@ -105,11 +105,11 @@
 		</div>-->
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Constant'lar (Sabitler)</h3>
+				<h3>Sabitler (Constants)</h3>
 				<p>
-					Kimi zaman program çalıştığı süre boyunca değeri hiç değişmeyecek olan bir variable yaratmak isteyebiliriz. Böyle variable'lara "constant" denir. Constant'lar normalde variable'ların kullanıldığı durumlarda kullanılmaz (mesela geçici bir değeri saklamak). Bir variable'ı constant olarak yaratmak için variable'ı ilk yazarken başına "final" kelimesini ekleyin. Constant'lar tüm metodların dışında yazılır, dolayısıyla kapsamları bütün programdır.
+					Kimi zaman program çalıştığı süre boyunca değeri hiç değişmeyecek olan bir değişken yaratmak isteyebiliriz. Böyle değişkenlere "sabit (constant)" denir. Sabitler normalde değişkenlerin kullanıldığı durumlarda kullanılmaz (örneğin geçici bir değeri saklamak). Bir değişkeni sabit olarak yaratmak için değişkeni ilk yazarken başına "final" kelimesini ekleyin. Sabitler tüm metodların dışında yazılır, dolayısıyla kapsamları bütün programdır.
 				</p>
-				<p> Constant'lar genellikle büyük harflerle yazılır. Bunun amacı onların constant olduğunu ve hiç değişmeyeceklerini belirtmektir. "private static final" kelimelerini ise iyi bir kodlama alışkanlığı olarak ekleriz. Bu kelimeler özellikle daha büyük programlar yazdığınızda önemli olacaktır.
+				<p> Sabitler genellikle büyük harflerle yazılır. Bunun amacı onların sabit olduğunu ve hiç değişmeyeceklerini belirtmektir. "private static final" kelimelerini ise iyi bir kodlama alışkanlığı olarak ekleriz. Bu kelimeler özellikle daha büyük programlar yazdığınızda önemli olacaktır.
 				<p>
 					Aşağıdaki örneğe bakın:
 				</p>

--- a/templates/tr/handouts/variables.html
+++ b/templates/tr/handouts/variables.html
@@ -27,18 +27,18 @@
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Local Variable'lar (Yerel Değişkenler)</h3>
+				<h3>Yerel Değişkenler (Local Variables)</h3>
 				<p>
-					Local variable'lar içinde yazıldıkları metot (veya bloklar, fazlası için aşağıdaki "Blok Kapsamı" bölümüne bakın) için yaratılır. Metodun yürütmesi bittiğinde de yok edilirler. Local variable'lar sadece içinde yazıldıkları metodda kullanılabilirler. Bu geçici özelliklerinden ötürü local variable'lar birden fazla metodda kullanılması gereken kalıcı bilgileri saklamak için kullanılmazlar.
+					Yerel Değişkenler içinde yazıldıkları metot (veya bloklar, fazlası için aşağıdaki "Blok Kapsamı" bölümüne bakın) için yaratılır. Metodun yürütmesi bittiğinde de yok edilirler. Yerel değişkenler sadece içinde yazıldıkları metotta kullanılabilirler. Bu geçici özelliklerinden ötürü Yerel değişkenler birden fazla metotta kullanılması gereken kalıcı bilgileri saklamak için kullanılmazlar.
 				</p>
 			</div>
 		</div>
 
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Local Variable Örnekleri</h3>
+				<h3>Yerel Değişken Örnekleri</h3>
 				<p>
-					Mesela aşağıdaki kod parçasına bakın.
+					Örnek olarak aşağıdaki kod parçasına bakın.
 				</p>
 				<pre id="editor" style="height:200px">public class AnExample extends ConsoleProgram {
 
@@ -48,16 +48,16 @@
  	}
 
 	public void methodTwo {
-		int b = a;  // BUG!: methodOne'da yazılmış local variable a methodTwo'da kullanılamaz.
+		int b = a;  // BUG!: methodOne'da yazılmış yerel değişkenler methodTwo içerisinde kullanılamaz.
 		println("b = " + b);
 	}
 }</pre>
 				<p>
-					a ve b variable'ları, AnExample class'ı içerisindeki farklı metodların içinde yazılmış local variable'lar. Bu variable'lar local variable'lar oldukları için a sadece methodOne'da, b ise sadece methodTwo'da erişilebilir. b variable'ını a'nın değerini kullanarak yaratmamız çalışmıyor çünkü methodTwo'da yazılan bu kod methodOne ya da başka herhangi bir method'daki local variable'ları kullanamaz.
+					a ve b değişkenleri, AnExample class'ı içerisindeki farklı metotların içinde yazılmış yerel değişkenlerdir. Bu değişkenler yerel oldukları için a sadece methodOne'da, b ise sadece methodTwo'da erişilebilir. b değişkenini a'nın değerini kullanarak yaratmamız hata veriyor çünkü methodTwo'da yazılan bu kod methodOne ya da başka herhangi bir metottaki yerel değişkenleri kullanamaz.
 				</p>
 				<p>
-				Local variable'ların değerleri içinde oldukları metodun yürütmesi bittikten sonra saklanmadığı için, methodOne'ın yürütmesi bittikten sonra a variable'ı yok olacak. methodOne tekrar yürütüldüğünde ise sıfırdan yeni bir a variable'ı yaratılacak.
-			</p>
+					Yerel değişkenlerin değerleri, içinde oldukları metodun yürütmesi bittikten sonra silindiği için, methodOne'ın yürütmesi bittikten sonra a değişkeni yok olacaktır. methodOne tekrar yürütüldüğünde ise sıfırdan yeni bir a değişkeni yaratılacak.
+				</p>
 			</div>
 		</div>
 
@@ -65,8 +65,8 @@
 			<div class="col-md-12">
 				<h3>Blok Kapsamı</h3>
 				<p>
-					Genelde local variable'ları belli bir metoda ait olarak düşünürüz, ancak aslında Java'da local variable'lar belli bir kod bloğuna aittir. Metodlar sadece bir çeşit kod bloğudur. Java'da kodun etrafına konan süslü parantezler ("{" ve "}") bir kod bloğu belirler. Mesela bir metodun başına ve sonuna konan süslü parantezler onu bir kod bloğu yapar. Ama aynısı for ve while döngüleri ve if kalıpları da kod bloklarıdır (etraflarında süslü parantez olduğu için). Java'da etrafında süslü parantez olan tüm kod grupları bir kod bloğudur.
-					Ne zaman bir süslü parantez çiftinin içinde bir variable yaratsak, o variable o kod bloğuna ait bir local variable olur ve ancak o blok içerisinde kullanılabilir. Ne zaman o kod bloğunun yürütmesi biterse o zaman da yok edilir.</p>
+					Genelde yerel değişkenleri belli bir metoda ait olarak düşünürüz, ancak aslında Java'da yerel değişkenler belli bir kod bloğuna aittir. Metodlar sadece bir çeşit kod bloğudur. Java'da kodun etrafına konan süslü parantezler ("{" ve "}") bir kod bloğu belirler. Mesela bir metodun başına ve sonuna konan süslü parantezler onu bir kod bloğu yapar. Ama aynısı for ve while döngüleri ve if kalıpları için de geçerlidir (etraflarında süslü parantez olduğu için). Java'da etrafında süslü parantez olan tüm kod grupları bir kod bloğudur.
+					Ne zaman bir süslü parantez çiftinin içinde bir değişken yaratsak, o değişken bulunduğu kod bloğuna ait bir yerel değişken olur ve ancak o blok içerisinde kullanılabilir. Ne zaman o kod bloğunun yürütmesi biterse o zaman da yok edilir.</p>
 				<p>Aşağıdaki örneğe bakın:</p>
 				<pre id="editor2" style="height:400px">public class AnExample extends ConsoleProgram {
 	
@@ -93,7 +93,7 @@
 	}
 }</pre>
 				<p>
-					a variable'ı methodThree'ye ait bir local variable, dolayısıyla hem for döngüsünün hem de println'nin içinde kullanılabilir. i ve b variable'ları ise sadece içinde yazıldıkları for loop'un içerisinde kapsam içindeler. Sondaki iki println yürütüldüğü zaman artık erişilebilir değiller. c variable'ı ise sadece içinde yazıldığı if kalıbının içinde kullanılabilir. Unutmayın ki for döngüsünün her bir döngüsünde if kalıbı baştan yürütüldüğü için c variable'ı da baştan yaratılıyor, dolayısıyla c variable'ı for'un farklı döngüleri arasında veri saklamaya uygun değil.
+					a değişkeni methodThree'ye ait bir yerel değişken, dolayısıyla hem for döngüsünün hem de println'nin içinde kullanılabilir. i ve b variable'ları ise sadece içinde yazıldıkları for döngüsü boyunca kapsam içindedirler. Sondaki iki println yürütüldüğü zaman artık erişilebilir olmayacaklardır. c değişkeni ise sadece içinde yazıldığı if kalıbının içinde kullanılabilir. Unutmayın ki for döngüsünün her bir döngüsünde if kalıbı baştan yürütüldüğü için c değişkeni de baştan yaratılıyor, dolayısıyla c değişkeni for'un farklı döngüleri arasında veri saklamaya uygun değil.
 				</p>
 			</div>
 		</div>
@@ -105,11 +105,11 @@
 		</div>-->
 		<div class="row">
 			<div class="col-md-12">
-				<h3>Constant'lar (Sabitler)</h3>
+				<h3>Sabitler (Constants)</h3>
 				<p>
-					Kimi zaman program çalıştığı süre boyunca değeri hiç değişmeyecek olan bir variable yaratmak isteyebiliriz. Böyle variable'lara "constant" denir. Constant'lar normalde variable'ların kullanıldığı durumlarda kullanılmaz (mesela geçici bir değeri saklamak). Bir variable'ı constant olarak yaratmak için variable'ı ilk yazarken başına "final" kelimesini ekleyin. Constant'lar tüm metodların dışında yazılır, dolayısıyla kapsamları bütün programdır.
+					Kimi zaman program çalıştığı süre boyunca değeri hiç değişmeyecek olan bir değişken yaratmak isteyebiliriz. Böyle değişkenlere "sabit (constant)" denir. Sabitler normalde değişkenlerin kullanıldığı durumlarda kullanılmaz (örneğin geçici bir değeri saklamak). Bir değişkeni sabit olarak yaratmak için değişkeni ilk yazarken başına "final" kelimesini ekleyin. Sabitler tüm metodların dışında yazılır, dolayısıyla kapsamları bütün programdır.
 				</p>
-				<p> Constant'lar genellikle büyük harflerle yazılır. Bunun amacı onların constant olduğunu ve hiç değişmeyeceklerini belirtmektir. "private static final" kelimelerini ise iyi bir kodlama alışkanlığı olarak ekleriz. Bu kelimeler özellikle daha büyük programlar yazdığınızda önemli olacaktır.
+				<p> Sabitler genellikle büyük harflerle yazılır. Bunun amacı onların sabit olduğunu ve hiç değişmeyeceklerini belirtmektir. "private static final" kelimelerini ise iyi bir kodlama alışkanlığı olarak ekleriz. Bu kelimeler özellikle daha büyük programlar yazdığınızda önemli olacaktır.
 				<p>
 					Aşağıdaki örneğe bakın:
 				</p>

--- a/templates/tr/index.html
+++ b/templates/tr/index.html
@@ -76,7 +76,7 @@
 				Bu Dersin Amacı
 			</h2>
 
-			<p>Bu iki haftalık dersin amacı, size daha sonrasında kendi başınıza öğrenmeye devam edebilecek seviyede programcılığın temellerini öğretmek. Stanford ve (Koç) Üniversitesi'nden gelen bir grup eğitmen tarafından verilecek. Programcılığı Stanford Üniversitesi'nin Bilgisayar Bilimine Giriş dersinde kullanılan materyeller üzerinden öğreneceksiniz.</p>
+			<p>Bu iki haftalık dersin amacı, size daha sonrasında kendi başınıza öğrenmeye devam edebilecek seviyede programcılığın temellerini öğretmektir. Dersler, Stanford ve Koç Üniversitesi'nden gelen bir grup eğitmen tarafından verilecektir. Programcılığı Stanford Üniversitesi'nin Bilgisayar Bilimine Giriş dersinde kullanılan materyeller üzerinden öğreneceksiniz.</p>
 
 		</div>
 
@@ -131,12 +131,12 @@
 	
 		<div class="section" id="playWithKarel">
 			<h2>
-				Karel'la Oyna
+				Karel ile Oyna
 			</h2>
 
-			<p>Meet Karel, The Java Robot that Stanford uses to introduce university students to programming. </p>
+			<p>Karel ile tanışın. Kendisi Stanford Üniversitesi tarafından öğrencileri programlama ile tanıştırmak amacıyla kullanılan bir Java robotudur. </p>
 
-			<p>Use Karel's commands to get her to move the beeper to the top of the ledge. Normally you will write your programs in an application called Eclipse, but to get you started we made a mini-eclipse for our website:</p>
+			<p>Karel komutlarını kullanarak "beeper"ını tepenin üstüne çıkartabilirsiniz. Normalde programlarınızı Eclipse isimli uygulama üzerinde yazacaksınız; fakat başlangıç olarak web sitemize bir mini-eclipse yerleştirdik:</p>
 			
 			%include templates/parts/playWithKarel.html
 		</div>

--- a/templates/tr/projects/8Ball.html
+++ b/templates/tr/projects/8Ball.html
@@ -30,7 +30,7 @@
 					8 Top'un arkasındaki fikir çok basit. Topa bir evet hayır sorusu soruyorsunuz, ve o da size cevabı söylüyor.
 				</p>
 
-				<p> Cevabın önceden hazırlanmış cevaplardan rastgele seçiliyor olması haricinde doğru cevabı söylüyor.</p>
+				<p> Cevabın önceden hazırlanmış cevaplardan rastgele seçiliyor olması haricinde doğru cevabı söylüyor. :)</p>
 				<p>
 					<center>
 						<img style="width:300px" src="{{pathToRoot}}img/projects/8Ball/real.gif">	

--- a/templates/tr/projects/awesome.html
+++ b/templates/tr/projects/awesome.html
@@ -22,10 +22,10 @@
 			</p>
 			<p>
 				Ders Notları: 
-				<a href="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 			<br/>
 				Çalışılan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/robotFace.html">Robot Surat</a>
+				<a href="{{pathToRoot}}tr/projects/robotFace.html">Robot Surat</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/borderBox.html
+++ b/templates/tr/projects/borderBox.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/borderSnake.html
+++ b/templates/tr/projects/borderSnake.html
@@ -22,8 +22,8 @@
 			</p>
 			<p>
                 Ders Notları:
-                <a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a><br/>
-				<a href ="{{pathToRoot}}tk/handouts/arrayLists.html">ArrayLists</a>
+                <a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a><br/>
+				<a href ="{{pathToRoot}}tr/handouts/arrayLists.html">Dizi Listeleri (ArrayLists)</a>
 			</p>
 
 		</div>
@@ -48,7 +48,7 @@
 
             <h2>İpucu:</h2>
             <ul>
-                <li>ArrayList kullanın!</li>
+                <li>Dizi Listesi (ArrayList) kullanın!</li>
                 <li>Yılanı hareket ettirirken, yılandaki her bloğu teker teker hareket ettirmenize gerek yok. Aslına bakarsanız tek bir bloğu hareket ettirmek yeterli olacaktır! Yılanın hareket ediyormuş gibi görünmesi için hangi bloğun tek başına hareket etmesinin yeterli olacağını düşünün.</li>
                 </ul>
             <h3>Değişmezler</h3>

--- a/templates/tr/projects/borderSnakeTutorial.html
+++ b/templates/tr/projects/borderSnakeTutorial.html
@@ -22,8 +22,8 @@
 			</p>
 			<p>
 				Ders Notları:
-                <a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a><br/>
-				<a href ="{{pathToRoot}}tk/handouts/arrayLists.html">ArrayLists</a>
+                <a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a><br/>
+				<a href ="{{pathToRoot}}tr/handouts/arrayLists.html">Dizi Listeleri (ArrayLists)</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/bouncingBall.html
+++ b/templates/tr/projects/bouncingBall.html
@@ -22,12 +22,12 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 				<br/>
 				Çalışan Örnek: 
-				<a href="{{pathToRoot}}tk/projects/mysterySquare.html">Gizemli Kare</a>,
-				<a href="{{pathToRoot}}tk/projects/gravityBall.html">Seken Top</a>,
-				<a href="{{pathToRoot}}tk/projects/goCenter.html">Merkeze Git</a>
+				<a href="{{pathToRoot}}tr/projects/mysterySquare.html">Gizemli Kare</a>,
+				<a href="{{pathToRoot}}tr/projects/gravityBall.html">Seken Top</a>,
+				<a href="{{pathToRoot}}tr/projects/goCenter.html">Merkeze Git</a>
 			</p>
 
 		</div>
@@ -87,7 +87,7 @@
 				<p>Topun konumunu nasıl bulacaksınız? Şu metotları kullanabilirsiniz:</p>
 				<div class="well"><code><i>object</i>.getX();<br/><i>object</i>.getY();</code></div>
 
-				<p>Bizim demomuza da göz gezdirmeyi ihmal etmeyin: <a href="{{pathToRoot}}tk/projects/gravityBall.html">Seken Top</a> ve <a href="{{pathToRoot}}tk/projects/goCenter.html">Merkeze Git</a></p>.
+				<p>Bizim demomuza da göz gezdirmeyi ihmal etmeyin: <a href="{{pathToRoot}}tr/projects/gravityBall.html">Seken Top</a> ve <a href="{{pathToRoot}}tr/projects/goCenter.html">Merkeze Git</a></p>.
 				
 			</div>
 		</div>

--- a/templates/tr/projects/breakout.html
+++ b/templates/tr/projects/breakout.html
@@ -24,9 +24,9 @@
 			</p>
 			<p>
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/events.html">Olaylar(Events) Referansı</a><br>
+				<a href ="{{pathToRoot}}tr/handouts/events.html">Olaylar(Events) Referansı</a><br>
 				Çalışan Örnek: 
-				<a href="{{pathToRoot}}tk/projects/stampTool.html">Damga Makinesi</a>
+				<a href="{{pathToRoot}}tr/projects/stampTool.html">Damga Makinesi</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/carbonDating.html
+++ b/templates/tr/projects/carbonDating.html
@@ -22,8 +22,8 @@
 			</p>
 			<p>
 				Çalışan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/emc2.html">E=MC2</a>,
-				<a href="{{pathToRoot}}tk/projects/fibb.html">Fibbonacci</a>
+				<a href="{{pathToRoot}}tr/projects/emc2.html">E=MC2</a>,
+				<a href="{{pathToRoot}}tr/projects/fibb.html">Fibbonacci</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/catchMeIfYouCan.html
+++ b/templates/tr/projects/catchMeIfYouCan.html
@@ -22,10 +22,10 @@
       </p>
       <p>
         Ders Notları:
-        <a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>, <a href ="{{pathToRoot}}tk/handouts/events.html">Events</a>
+        <a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>, <a href ="{{pathToRoot}}tr/handouts/events.html">Events</a>
         <br/>
          Çalışılan Örnekler:
-         <a href ="{{pathToRoot}}tk/projects/stampTool.html">Damga Makinesi</a>
+         <a href ="{{pathToRoot}}tr/projects/stampTool.html">Damga Makinesi</a>
       </p>
 
     </div>

--- a/templates/tr/projects/checkerBoard.html
+++ b/templates/tr/projects/checkerBoard.html
@@ -24,7 +24,7 @@
 			</p>
 			<p>
 				Ders Notları:
-                <a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a><br/>
+                <a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a><br/>
 			</p>
 
 		</div>
@@ -32,9 +32,6 @@
 
 		<div class="row">
 			<div class="col-md-12">
-				<p>
-						This is a bonus program! It's meant to be challenging.
-				</p>
 				<p>
 					Bu bir bonus programdır! Biraz zorlayıcı olması için hazırlanmıştır, ancak bu egzersizi tamamlamak kesinlikle Final Projesnize yardımcı olacaktır.
 				<p>

--- a/templates/tr/projects/clickNStuff.html
+++ b/templates/tr/projects/clickNStuff.html
@@ -22,8 +22,8 @@
 			</p>
 			<p>
                 Ders Notları:
-                <a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a><br/>
-				<a href ="{{pathToRoot}}tk/handouts/events.html">Olaylar(Events) Referansı</a>
+                <a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a><br/>
+				<a href ="{{pathToRoot}}tr/handouts/events.html">Olaylar(Events) Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/collectNewspaper.html
+++ b/templates/tr/projects/collectNewspaper.html
@@ -26,10 +26,10 @@
 				Methods
 				<br/>-->
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 				<br/>
 				Çalışılan Örnek: 
-				<a href="{{pathToRoot}}tk/projects/stepUp.html">Adım Adım</a>
+				<a href="{{pathToRoot}}tr/projects/stepUp.html">Adım Adım</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/consoleBonus.html
+++ b/templates/tr/projects/consoleBonus.html
@@ -24,8 +24,8 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/console.html">Konsol Referansı</a><br/>
-				<a href ="{{pathToRoot}}tk/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a><br/>
+				<a href ="{{pathToRoot}}tr/handouts/console.html">Konsol Referansı</a><br/>
+				<a href ="{{pathToRoot}}tr/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a><br/>
 			</p>
 
 		</div>

--- a/templates/tr/projects/countdown.html
+++ b/templates/tr/projects/countdown.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
                 Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/creativeGraphics.html
+++ b/templates/tr/projects/creativeGraphics.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 				<br/>
 			</p>
 

--- a/templates/tr/projects/creativeStringArt.html
+++ b/templates/tr/projects/creativeStringArt.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 				<br/>
 			</p>
 
@@ -35,7 +35,7 @@
 					Bu bir bonus programdır! Biraz zorlayıcı olması için hazırlanmıştır, ancak bu egzersizi tamamlamak kesinlikle Final Projenize yardımcı olacaktır.
 				</p>
 				<p>
-					Daha önce yazdığınız <a href="{{pathToRoot}}tk/projects/stringArt.html">String Sanatı</a> programının bir uzantısı olacak bir GraphicsProgram yazım. Bu sefer ekrana 4 eğri ekleyin.
+					Daha önce yazdığınız <a href="{{pathToRoot}}tr/projects/stringArt.html">String Sanatı</a> programının bir uzantısı olacak bir GraphicsProgram yazım. Bu sefer ekrana 4 eğri ekleyin.
 				</p>
 				<p>
 					<center>

--- a/templates/tr/projects/drawPeople.html
+++ b/templates/tr/projects/drawPeople.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/duplicatingShapes.html
+++ b/templates/tr/projects/duplicatingShapes.html
@@ -22,9 +22,9 @@
 			</p>
 			<p>
 				Ders Notları:
-                <a href ="{{pathToRoot}}tk/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a><br/>
-                <a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a><br/>
-                <a href ="{{pathToRoot}}tk/handouts/events.html">Olaylar(Events) Referansı</a><br/>
+                <a href ="{{pathToRoot}}tr/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a><br/>
+                <a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a><br/>
+                <a href ="{{pathToRoot}}tr/handouts/events.html">Olaylar(Events) Referansı</a><br/>
 			</p>
 
 		</div>

--- a/templates/tr/projects/efes.html
+++ b/templates/tr/projects/efes.html
@@ -22,10 +22,10 @@
 			</p>
 			<p>
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 				<br/>
 				Çalışılan Örnek: 
-				<a href="{{pathToRoot}}tk/projects/place100.html">100 Koymak</a>
+				<a href="{{pathToRoot}}tr/projects/place100.html">100 Koymak</a>
 			</p>
 
 		</div>
@@ -89,7 +89,7 @@
 							<br/>}
 						</code>
 					</div>
-					Başka bir örnek için <a href="{{pathToRoot}}tk/projects/place100.html">100 Koymak</a> programını görün.
+					Başka bir örnek için <a href="{{pathToRoot}}tr/projects/place100.html">100 Koymak</a> programını görün.
 				</p>
 				<p>Eğer for döngülerini kullanırsanız, programınızı yazması ve okuması çok daha kolay olacak. Bu problemde for döngüleri kullanmanın birçok avantajı var!
 			</div>

--- a/templates/tr/projects/favoriteNumber.html
+++ b/templates/tr/projects/favoriteNumber.html
@@ -23,9 +23,9 @@
 
 			<p>
 				Çalışan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/emc2.html">E=MC2</a>,
-				<a href="{{pathToRoot}}tk/projects/fibb.html">Fibbonacci</a>,
-				<a href="{{pathToRoot}}tk/projects/carbonDating.html">Karbon Tarihi Saptama</a>
+				<a href="{{pathToRoot}}tr/projects/emc2.html">E=MC2</a>,
+				<a href="{{pathToRoot}}tr/projects/fibb.html">Fibbonacci</a>,
+				<a href="{{pathToRoot}}tr/projects/carbonDating.html">Karbon Tarihi Saptama</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/findPi.html
+++ b/templates/tr/projects/findPi.html
@@ -27,7 +27,7 @@
 		<div class="row">
 			<div class="col-md-12">
 				<p>
-					Pi (&pi;) gerçen güzelliğin matematiksel halidir. Birçok denklemde karşımıza çıkar. Özellikle de dairesel hesaplar yaparken, çan eğrisi hesaplarken ve son olarak da, inanılmaz bir şekilde, <a href="https://tr.0wikipedia.org/wiki/Euler_%C3%B6zde%C5%9Fli%C4%9Fi">Euler Özdeşliği'nde</a>.
+					Pi (&pi;) gerçek güzelliğin matematiksel halidir. Birçok denklemde karşımıza çıkar. Özellikle de dairesel hesaplar yaparken, çan eğrisi hesaplarken ve son olarak da, inanılmaz bir şekilde, <a href="https://tr.0wikipedia.org/wiki/Euler_%C3%B6zde%C5%9Fli%C4%9Fi">Euler Özdeşliği'nde</a>.
 				</p>
 
 				<p>Peki &pi; değerinin 3.14159265359... olduğunu nereden bliyoruz? Pi sayısını hesaplamanın birçok yöntemi var. Bu egzersiz ile pi sayısını dart tahtasını kullanarak hesaplamayı öğreneceğiz.</p>

--- a/templates/tr/projects/gameOfStones.html
+++ b/templates/tr/projects/gameOfStones.html
@@ -30,8 +30,8 @@
 			</p>
 			<p>
 				Çalışılan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/emc2.html">E=MC2</a>,
-				<a href="{{pathToRoot}}tk/projects/fibb.html">Fibonacci</a>
+				<a href="{{pathToRoot}}tr/projects/emc2.html">E=MC2</a>,
+				<a href="{{pathToRoot}}tr/projects/fibb.html">Fibonacci</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/hailstone.html
+++ b/templates/tr/projects/hailstone.html
@@ -22,8 +22,8 @@
 			</p>
 			<p>
 				Çalışan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/emc2.html">E=MC2</a>,
-				<a href="{{pathToRoot}}tk/projects/fibb.html">Fibbonacci</a>
+				<a href="{{pathToRoot}}tr/projects/emc2.html">E=MC2</a>,
+				<a href="{{pathToRoot}}tr/projects/fibb.html">Fibbonacci</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/halfGreen.html
+++ b/templates/tr/projects/halfGreen.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/illusion.html
+++ b/templates/tr/projects/illusion.html
@@ -22,10 +22,10 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 				<br/>
 				Çalışılan Örnek: 
-				<a href="{{pathToRoot}}tk/projects/stringArtSoln.html">String Sanatı</a>
+				<a href="{{pathToRoot}}tr/projects/stringArtSoln.html">String Sanatı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/invert.html
+++ b/templates/tr/projects/invert.html
@@ -23,7 +23,7 @@
 
 			<p>
 			Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/jawascript.html
+++ b/templates/tr/projects/jawascript.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/projects/jsJSSyntax.html">JavaScript Syntax Referansı</a>
+				<a href ="{{pathToRoot}}tr/projects/jsJSSyntax.html">JavaScript Syntax Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/madLibs.html
+++ b/templates/tr/projects/madLibs.html
@@ -21,7 +21,7 @@
         Hazırlayanlar: Julia Lee ve Bryce Cronkite-Ratcliff
       </p>
       <p>
-        Örnek: <a href="{{pathToRoot}}tk/projects/madMax.html">Mad Max</a>
+        Örnek: <a href="{{pathToRoot}}tr/projects/madMax.html">Mad Max</a>
       </p>
 
     </div>

--- a/templates/tr/projects/madMax.html
+++ b/templates/tr/projects/madMax.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Örnek:
-				<a href ="{{pathToRoot}}tk/projects/halfGreen.html">Yarısı Yeşil</a>
+				<a href ="{{pathToRoot}}tr/projects/halfGreen.html">Yarısı Yeşil</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/madMethods.html
+++ b/templates/tr/projects/madMethods.html
@@ -22,9 +22,9 @@
 			</p>
 			<p>
 				Örnekler:
-				<a href ="{{pathToRoot}}tk/projects/averageMethod.html">Ortalama Metodu</a>,
-				<a href ="{{pathToRoot}}tk/projects/drawPeople.html">İnsan Çizme</a>,
-				<a href ="{{pathToRoot}}tk/projects/halfGreen.html">Yarısı Yeşil</a>
+				<a href ="{{pathToRoot}}tr/projects/averageMethod.html">Ortalama Metodu</a>,
+				<a href ="{{pathToRoot}}tr/projects/drawPeople.html">İnsan Çizme</a>,
+				<a href ="{{pathToRoot}}tr/projects/halfGreen.html">Yarısı Yeşil</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/makingTracks.html
+++ b/templates/tr/projects/makingTracks.html
@@ -23,10 +23,10 @@
 
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/events.html">Events</a>
+				<a href ="{{pathToRoot}}tr/handouts/events.html">Olaylar (Events)</a>
 			<br/>
 				Çalışılan Örnekler: 	
-				<a href="{{pathToRoot}}tk/projects/stampTool.html">Stamp Tool</a>
+				<a href="{{pathToRoot}}tr/projects/stampTool.html">Damga Makinası</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/medicine.html
+++ b/templates/tr/projects/medicine.html
@@ -22,9 +22,9 @@
 			</p>
 			<p>
 				Çalışılan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/emc2.html">E=MC2</a>,
-				<a href="{{pathToRoot}}tk/projects/fibb.html">Fibonacci</a>,
-				<a href="{{pathToRoot}}tk/projects/carbonDating.html">Karbon Tarihi Saptama</a>
+				<a href="{{pathToRoot}}tr/projects/emc2.html">E=MC2</a>,
+				<a href="{{pathToRoot}}tr/projects/fibb.html">Fibonacci</a>,
+				<a href="{{pathToRoot}}tr/projects/carbonDating.html">Karbon Tarihi Saptama</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/midpointKarel.html
+++ b/templates/tr/projects/midpointKarel.html
@@ -24,7 +24,7 @@
 			</p>
 			<p>
 				Handouts:
-                <a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a><br/>
+                <a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a><br/>
 			</p>
 
 		</div>

--- a/templates/tr/projects/mountain.html
+++ b/templates/tr/projects/mountain.html
@@ -23,10 +23,10 @@
 
 			<p>
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 				<br/>
 				Çalışılan Örnek: 
-				<a href="{{pathToRoot}}tk/projects/beeperLine.html">Beeper Hattı</a>
+				<a href="{{pathToRoot}}tr/projects/beeperLine.html">Beeper Hattı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/movingCircle.html
+++ b/templates/tr/projects/movingCircle.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Dern Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/multipleBalls.html
+++ b/templates/tr/projects/multipleBalls.html
@@ -24,8 +24,8 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a><br/>
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a><br/>
+				<a href ="{{pathToRoot}}tr/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a><br/>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a><br/>
 			</p>
 
 		</div>

--- a/templates/tr/projects/music.html
+++ b/templates/tr/projects/music.html
@@ -22,9 +22,9 @@
 			</p>
 			<p>
 				Örnek:
-				<a href ="{{pathToRoot}}tk/projects/snow.html">Kar</a>
+				<a href ="{{pathToRoot}}tr/projects/snow.html">Kar</a>
 				<br/>Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/arrayLists.html">ArrayList'ler</a>
+				<a href ="{{pathToRoot}}tr/handouts/arrayLists.html">Dizi Listeleri (ArrayLists)</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/musicCannon.html
+++ b/templates/tr/projects/musicCannon.html
@@ -22,14 +22,14 @@
                 </p>
                 <p>
                         Ders Notları:
-                        <a href ="{{pathToRoot}}tk/projects/jsJSSyntax.html">JavaScript Syntax Referansı</a>
+                        <a href ="{{pathToRoot}}tr/projects/jsJSSyntax.html">JavaScript Syntax Referansı</a>
                 </p>
 			
 
 		</div>
 		<hr/>
 
-<       p>İstemciler! Sunucular! Muzik! Bir araya gelince daha da lezzetli olan üç harika lezzet!</p>
+<       <p>İstemciler! Sunucular! Muzik! Bir araya gelince daha da lezzetli olan üç harika lezzet!</p>
 
         <p>Göreviniz bir imtemci programı yazmak. Bu program kullanıcıya bir metin kutusu sunacak. 
 	Kullanıcı bu metin kutusuna bir notanın ismini girdiğinde ve 'Enter' tuşuna bastığında,

--- a/templates/tr/projects/numberGrid.html
+++ b/templates/tr/projects/numberGrid.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 				<br/>
 			</p>
 

--- a/templates/tr/projects/place100.html
+++ b/templates/tr/projects/place100.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/randomCircles.html
+++ b/templates/tr/projects/randomCircles.html
@@ -22,10 +22,10 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 				<br/>
 				Çalışan Örnek: 
-				<a href="{{pathToRoot}}tk/projects/8Ball.html">8 Numaralı Top</a>
+				<a href="{{pathToRoot}}tr/projects/8Ball.html">8 Numaralı Top</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/randomOvals.html
+++ b/templates/tr/projects/randomOvals.html
@@ -22,10 +22,10 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/jsgraphics.html">Javascript Grafikleri</a>
+				<a href ="{{pathToRoot}}tr/handouts/jsgraphics.html">Javascript Grafikleri</a>
 				<br/>
 				Çalışılan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/breakoutOnline.html">Çevrimiçi Breakout!</a>
+				<a href="{{pathToRoot}}tr/projects/breakoutOnline.html">Çevrimiçi Breakout!</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/randomPainter.html
+++ b/templates/tr/projects/randomPainter.html
@@ -23,10 +23,10 @@
 
 			<p>
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 				<br/>Çalışılan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/invert.html">Ters Çevir</a>,
-				<a href="{{pathToRoot}}tk/projects/unKarel.html">İnsani Yardım Karel'i</a>
+				<a href="{{pathToRoot}}tr/projects/invert.html">Ters Çevir</a>,
+				<a href="{{pathToRoot}}tr/projects/unKarel.html">İnsani Yardım Karel'i</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/sandcastles.html
+++ b/templates/tr/projects/sandcastles.html
@@ -20,13 +20,13 @@
 
 			<p>
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/console.html">Konsol Referansı</a>,
-				<a href ="{{pathToRoot}}tk/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/console.html">Konsol Referansı</a>,
+				<a href ="{{pathToRoot}}tr/handouts/random.html">Rasgele Sayı Üreticisi Referansı</a>
 		`<br/>
 				Çalışılan Örnekler: 
-				<a href="{{pathToRoot}}tk/projects/emc2.html">E=MC2</a>,
-				<a href="{{pathToRoot}}tk/projects/fibb.html">Fibbonacci</a>,
-				<a href="{{pathToRoot}}tk/projects/carbonDating.html">Karbon Tarihi Saptama</a>
+				<a href="{{pathToRoot}}tr/projects/emc2.html">E=MC2</a>,
+				<a href="{{pathToRoot}}tr/projects/fibb.html">Fibbonacci</a>,
+				<a href="{{pathToRoot}}tr/projects/carbonDating.html">Karbon Tarihi Saptama</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/secret.html
+++ b/templates/tr/projects/secret.html
@@ -22,9 +22,9 @@
 			</p>
 			<p>
 				Örnek:
-				<a href ="{{pathToRoot}}tk/projects/snow.html">Kar</a>
+				<a href ="{{pathToRoot}}tr/projects/snow.html">Kar</a>
 				<br/>Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/arrayLists.html">Array List'ler</a>
+				<a href ="{{pathToRoot}}tr/handouts/arrayLists.html">Array List'ler</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/snow.html
+++ b/templates/tr/projects/snow.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/arrayLists.html">ArrayList Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/arrayLists.html">Dizi Listeleri (ArrayList) Referansı</a>
 				
 			</p>
 

--- a/templates/tr/projects/stepUp.html
+++ b/templates/tr/projects/stepUp.html
@@ -27,7 +27,7 @@
 				Methods
 			<br/>-->
 			Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/stringArt.html
+++ b/templates/tr/projects/stringArt.html
@@ -41,7 +41,7 @@
 
 		<div class="row">
 			<div class="col-md-12">
-				<h2>Starter Code</h2>
+				<h2>Başlangıç Kodu</h2>
 
 
 <pre id="editor" style="height:400px">public class StringArt extends GraphicsProgram {

--- a/templates/tr/projects/stringArtSoln.html
+++ b/templates/tr/projects/stringArtSoln.html
@@ -15,10 +15,10 @@
 		<!-- Header -->
 		<div id="pageHeader">
 			<h1>
-				String Art
+				String Sanatı
 			</h1>
 			<p>
-				Based on a demonstration by Eric Roberts.
+				Eric Roberts'ın bir gösterimi temel alınmıştır.
 			</p>
 
 		</div>
@@ -27,7 +27,7 @@
 		<div class="row">
 			<div class="col-md-12">
 				<p>
-					By repeatedly drawing lines, we can make a curved looking shape. Consider the example below where we imagine dots evenly space along the bottom and the left of a canvas. If we connect the topmost dot on the left edge to the left most dot on the right edge, we would be a line like the picture of the far left. If we then connect the next 10 dots we get a picture in the middle and if we connect all dots we get the picture on the right.
+					Tekrar tekrar çizgiler çizerek, kavisli görünen bir şekil yaratabiliriz. Kanvasın (canvas) altı ve solu boyunca eşit aralıklarla ayrılmış noktaları hayal ettiğimiz aşağıdaki örneğe bakalım. Eğer sol kenarda en üstteki nokta ile alt kenarda en soldaki noktayı birleştirirsek, soldaki resimdeki doğru oluşur. Eğer sıradaki 10 noktayı da aynı şekilde birleştirirsek ortadaki resmi ve bütün noktaları birleştirirsek sağdaki resmi elde ederiz.
 				</p>
 				
 				<p>
@@ -35,13 +35,13 @@
 						<img style="width:700px" src="{{pathToRoot}}img/projects/stringArt/startToEnd.png">	
 					</center>
 				</p>
-				<p>Write a program that creates the "curve" in the above right image using straight lines.</p>
+				<p>Doğruları kullanarak üstte sağdaki resimdeki "eğriyi" yaratan bir program yazın..</p>
 			</div>
 		</div>
 
 		<div class="row">
 			<div class="col-md-12">
-				<h2>Starter Code</h2>
+				<h2>Başlangıç Kodu</h2>
 
 
 <pre id="editor" style="height:270px">public class StringArt extends GraphicsProgram {

--- a/templates/tr/projects/sunset.html
+++ b/templates/tr/projects/sunset.html
@@ -22,8 +22,8 @@
 			</p>
 			<p>
 				Örnekler:
-				<a href ="{{pathToRoot}}tk/projects/halfGreen.html">Yarısı Yeşil</a>,
-				<a href ="{{pathToRoot}}tk/projects/target.html">Hedef Tahtası</a>
+				<a href ="{{pathToRoot}}tr/projects/halfGreen.html">Yarısı Yeşil</a>,
+				<a href ="{{pathToRoot}}tr/projects/target.html">Hedef Tahtası</a>
 				<br/>
 			Ders Notları:
 				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>

--- a/templates/tr/projects/target.html
+++ b/templates/tr/projects/target.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları:
-				<a href ="{{pathToRoot}}tk/handouts/graphics.html">Grafik Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/graphics.html">Grafik Referansı</a>
 			</p>
 
 		</div>

--- a/templates/tr/projects/unKarel.html
+++ b/templates/tr/projects/unKarel.html
@@ -22,7 +22,7 @@
 			</p>
 			<p>
 				Ders Notları: 
-				<a href ="{{pathToRoot}}tk/handouts/karel.html">Karel Referansı</a>
+				<a href ="{{pathToRoot}}tr/handouts/karel.html">Karel Referansı</a>
 			</p>	
 
 		</div>


### PR DESCRIPTION
I did my best to find grammar errors etc.
The next best thing to do could be ask for students to report the errors they find during csBridge.
Also tried to compile but gave error when compiling for some files in /en which I did not touch (might be due to python version required) so you need to recompile.